### PR TITLE
Fix.

### DIFF
--- a/src/js/lib/agents/graph.js
+++ b/src/js/lib/agents/graph.js
@@ -328,14 +328,11 @@ class GraphAgent {
     return fetch(Util.uriToProxied(uri),{
       credentials: 'include' 
     }).then((ans) => {
-      if (ans.ok){
-        return ans.text().then((res)=>{
-          return parser.parse(res, uri) 
-        })
-        // This is later used for displaying broken nodes.
-      } else {
-        return {uri: uri, unav : true, connection:null,  triples:[]} 
-      }
+      return ans.text().then((res)=>{
+        return parser.parse(res, uri) 
+      })
+    }).catch(()=>{
+      return {uri: uri, unav : true, connection:null,  triples:[]} 
     })
   }
 


### PR DESCRIPTION
Better to use catch then res.ok.
Catching errors rather than just using res.ok, this way we have better error handling and prevent the crash.