### PR TITLE
"Copy URL" feature on node profile

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "react-addons-create-fragment": "^15.0.0",
     "react-addons-transition-group": "^15.0.0",
     "react-addons-update": "^15.0.0",
+    "react-copy-to-clipboard": "^4.2.2",
     "react-dom": "^15.0.0",
     "react-router": "^1.0.3",
     "react-tap-event-plugin": "^1.0.0",

--- a/src/js/components/node/profile.jsx
+++ b/src/js/components/node/profile.jsx
@@ -4,6 +4,7 @@ import Radium from 'radium'
 import graphActions from 'stores/graph-store'
 import nodeActions from 'actions/node'
 import Utils from 'lib/util'
+import CopyToClipboard from 'react-copy-to-clipboard';
 
 import {
   AppBar,
@@ -154,9 +155,14 @@ let ProfileNode = React.createClass({
             <MenuItem
               primaryText={fullscreenLabel}
               onTouchTap={this._handleFull} />
-            <MenuItem
-              primaryText="Copy URL"
-              onTouchTap={this._handleCopyURL}/>
+              
+            <CopyToClipboard
+              text={this.props.state.center.uri} 
+              onCopy={this._handlePostCopyURL}>
+                <MenuItem
+                  primaryText="Copy URL" />
+            </CopyToClipboard>
+            
             <MenuItem
               primaryText="Delete"
               onTouchTap={this._handleDelete}/>
@@ -258,8 +264,8 @@ let ProfileNode = React.createClass({
     }
   },
 
-  _handleCopyURL() {
-
+  _handlePostCopyURL() {
+    alert('The URL was copied to the clipboard.')
   },
 
   _handleStartChat() {

--- a/src/js/components/node/profile.jsx
+++ b/src/js/components/node/profile.jsx
@@ -265,6 +265,7 @@ let ProfileNode = React.createClass({
   },
 
   _handlePostCopyURL() {
+    // @TODO implement snackbars/toasts
     alert('The URL was copied to the clipboard.')
   },
 


### PR DESCRIPTION
When visiting the page of a node, clicking on "Copy URL" copies the URL of the node to the clipboard.